### PR TITLE
query_parameters may already been present in url (#1)

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -135,7 +135,11 @@ class HttpClient
     protected function buildUrlQuery($url, $parameters = [])
     {
         if (!empty($parameters)) {
-            $url .= '?' . \http_build_query($parameters);
+            if (false !== strpos($url, '?') {
+                $url .= '&' . \http_build_query($parameters);
+            } else {
+                $url .= '?' . \http_build_query($parameters);
+            }
         }
 
         return $url;

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -135,7 +135,7 @@ class HttpClient
     protected function buildUrlQuery($url, $parameters = [])
     {
         if (!empty($parameters)) {
-            if (false !== strpos($url, '?') {
+            if (false !== strpos($url, '?')) {
                 $url .= '&' . \http_build_query($parameters);
             } else {
                 $url .= '?' . \http_build_query($parameters);


### PR DESCRIPTION
Fix concatenation chars if url already contains a '?'
Eg: /?rest_route=/ 
when using php -S debug mode
Query parameters should be added using '&'