### PR TITLE
HTTP method override feature for web-servers that don't allow PUT and DELETE

### DIFF
--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -145,4 +145,28 @@ class Options
     {
         return isset($this->options['follow_redirects']) ? (bool) $this->options['follow_redirects'] : false;
     }
+
+    /**
+     * Check is it needed to mask all non-GET/POST methods (PUT/DELETE/etc.) by using POST method with added
+     * query parameter ?_method=METHOD into URL
+     *
+     * @return bool
+     */
+    public function isMethodOverrideQuery()
+    {
+        return isset($this->options['method_override_query']) && $this->options['method_override_query'];
+    }
+
+    /**
+     * Check is it needed to mask all non-GET/POST methods (PUT/DELETE/etc.) by using POST method with added
+     * "X-HTTP-Method-Override: METHOD" HTTP header into request
+     *
+     * @return bool
+     */
+    public function isMethodOverrideHeader()
+    {
+        return isset($this->options['method_override_header']) && $this->options['method_override_header'];
+    }
+
+
 }

--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -167,6 +167,4 @@ class Options
     {
         return isset($this->options['method_override_header']) && $this->options['method_override_header'];
     }
-
-
 }


### PR DESCRIPTION
Added HTTP method override feature for web-servers that restrict HTTP method to GET and POST only (don't allow PUT and DELETE)

Some web-servers restrict HTTP methods to only GET and POST. Woo-Commerce uses PUT and DELETE in its API. But there are 2 workarounds for such servers:
1. Use the POST method and add the "_method=" query parameter to the URL using the real HTTP method.
2. Use the POST method and add the "X-HTTP-Method-Override" HTTP header with real HTTP method to the request.

Both variants are equivalent. And they can even be used together. This fork adds possibility to use these workarounds.

More information on this can be found here:

 * https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header
 * https://gridpane.com/kb/put-requests-woocommerce-api/
 * https://gridpane.com/kb/making-nginx-accept-put-delete-and-patch-verbs/
 * https://github.com/woocommerce/woocommerce/issues/15218

All you need to do to activate workaround is to add 1 or 2 options to constructor of the Client like in this example:

```php
use Automattic\WooCommerce\Client;

$client = new Client($url, $consumerKey, $consumerSecret, [
    'wp_api' => true,
    'version' => 'wc/v3',
    'follow_redirects' => true,
    'query_string_auth' => true,
    'timeout' => 60,
    'method_override_query' => true,
    'method_override_header' => false,
]);
```

The options `method_override_query` activates `?_method=PUT/DELETE` workaround. And the option `method_override_header` activates workaround with `X-HTTP-Method-Override` header. Usually it's enough to activate only one of them, but you can activate they both if you want.

If you want to better understand how it's working on Woo-Commerce side, you can review the code in the file `class-wc-api-server.php`. At the moment this code looks like this:

```php
// Compatibility for clients that can't use PUT/PATCH/DELETE
if ( isset( $_GET['_method'] ) ) {
    $this->method = strtoupper( $_GET['_method'] );
} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
    $this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
}
```
