### PR TITLE
More than 1 url param & becomes html encoded

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -149,7 +149,7 @@ class HttpClient
             }
         }
 
-        return $url;
+        return html_entity_decode($url);
     }
 
     /**


### PR DESCRIPTION
When using more than 1 parameter in the GET, the URL somehow becomes html encoded. Just run html_entity_decode on it, it won't hurt, and it helps me with my 4 parameter get statement.