### PR TITLE
Fix: Warning thrown in HttpClient if $errors is an empty array

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -372,7 +372,7 @@ class HttpClient
             $errorMessage = '';
             $errorCode = '';
 
-            if (is_array($errors)) {
+            if (is_array($errors) && !empty($errors)) {
                 $errorMessage = $errors[0]->message;
                 $errorCode    = $errors[0]->code;
             } elseif (isset($errors->message, $errors->code)) {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -372,7 +372,7 @@ class HttpClient
             $errorMessage = '';
             $errorCode = '';
 
-            if (is_array($errors) && !empty($errors)) {
+            if (is_array($errors) && $errors) {
                 $errorMessage = $errors[0]->message;
                 $errorCode    = $errors[0]->code;
             } elseif (isset($errors->message, $errors->code)) {


### PR DESCRIPTION
Added an additional check to prevent warnings thrown in HttpClient if the $errors array is empty.