### PR TITLE
Fix query string parameters when arg_separator.output is configured as &amp;

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -149,7 +149,7 @@ class HttpClient
             }
         }
 
-        return $url;
+        return html_entity_decode($url);
     }
 
     /**

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -143,13 +143,13 @@ class HttpClient
     {
         if (!empty($parameters)) {
             if (false !== strpos($url, '?')) {
-                $url .= '&' . \http_build_query($parameters);
+                $url .= '&' . \http_build_query($parameters, '', '&');
             } else {
-                $url .= '?' . \http_build_query($parameters);
+                $url .= '?' . \http_build_query($parameters, '', '&');
             }
         }
 
-        return html_entity_decode($url);
+        return $url;
     }
 
     /**


### PR DESCRIPTION
without html decoding the url here, the url get's messed up and doesn't honor any of the filter parameters past the first 1