### PR TITLE
Fix typo in readme for orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $woocommerce->options($endpoint);
 
 | Params       | Type     | Description                                                  |
 | ------------ | -------- | ------------------------------------------------------------ |
-| `endpoint`   | `string` | WooCommerce API endpoint, example: `customers` or `order/12` |
+| `endpoint`   | `string` | WooCommerce API endpoint, example: `customers` or `orders/12` |
 | `data`       | `array`  | Only for POST and PUT, data that will be converted to JSON   |
 | `parameters` | `array`  | Only for GET and DELETE, request query string                |
 


### PR DESCRIPTION
This PR fixes the typo noted in #347 for the `orders/` endpoint.

### Testing

1. Verify that the updated endpoint matches that of the docs - https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-an-order
2. Optionally test with the following snippet:
```php
$woocommerce = new Client(
    'http://merchanturl.local',
    'consumer_key',
    'consumer_secret',
    [
        'wp_api'  => true,
        'version' => 'wc/v3',
    ]
);
$orders = $woocommerce->get('orders', ['status'=>'processing', 'per_page'=>1]);
print_r($orders);
```