### PR TITLE
Add a stalebot workflow to close PRs and issues with no activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,12 @@ on:
     # Run every day at 1:00 AM UTC
     - cron: "0 1 * * *"
   workflow_dispatch:
+    inputs:
+      debug_only:
+        description: 'Run in debug-only mode (no actual changes)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   issues: write
@@ -17,6 +23,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: ${{ inputs.debug_only }}
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you
@@ -33,10 +40,10 @@ jobs:
             this is still needed, please feel free to reopen it.
           stale-issue-label: stale
           stale-pr-label: stale
-          days-before-stale: 7
+          days-before-stale: 60
           days-before-close: 7
           days-before-pr-stale: 30
-          days-before-pr-close: 14
-          exempt-issue-labels: bug,enhancement
-          exempt-pr-labels: bug,enhancement
+          days-before-pr-close: 3
+          exempt-issue-labels: pinned,security,bug,enhancement,documentation
+          exempt-pr-labels: pinned,security,bug,enhancement,documentation
           operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: "Close stale issues and pull requests"
+
+on:
+  schedule:
+    # Run every day at 1:00 AM UTC
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity. If you think
+            this is still an issue, please feel free to reopen it.
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity. If you think
+            this is still needed, please feel free to reopen it.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-stale: 7
+          days-before-close: 7
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          exempt-issue-labels: bug,enhancement
+          exempt-pr-labels: bug,enhancement
+          operations-per-run: 100


### PR DESCRIPTION
This PR adds a stale workflow to close old issues and PRs with no activity.  Given our limited time to maintain this repo, we want to make sure that we focus time on issues that are reproducible and where issue authors are active.

### Testing

1. Merge this PR
2. Test with `debug-only` made as `true` first
3. Verify that stale issues/PRs are identified 
4. Make sure that properties are [accurate](https://github.com/actions/stale) and match similar expectations to [those in core](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/stalebot.yml)