### PR TITLE
Fix return types for GET endpoints and assoc methods

### DIFF
--- a/src/WooCommerce/Client.php
+++ b/src/WooCommerce/Client.php
@@ -75,7 +75,7 @@ class Client
      * @param string $endpoint   API endpoint.
      * @param array  $parameters Request parameters.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function get($endpoint, $parameters = [])
     {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -392,7 +392,7 @@ class HttpClient
     /**
      * Process response.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     protected function processResponse()
     {
@@ -429,7 +429,7 @@ class HttpClient
      * @param array  $data       Request data.
      * @param array  $parameters Request parameters.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function request($endpoint, $method, $data = [], $parameters = [])
     {


### PR DESCRIPTION
Fix return types for GET endpoints and assoc methods that return either an array or a stdclass

Here is two GET endpoints that return an array or stdclass:

https://woocommerce.github.io/woocommerce-rest-api-docs/?php#retrieve-an-order-note
https://woocommerce.github.io/woocommerce-rest-api-docs/?php#list-all-order-notes

This convention seems to be followed across the board when using GET to query one/many endpoints

No testing methodology needed, you can just view the return examples of the api and see either array or stdclass can be returned.

Ty!