### PR TITLE
handle curl_close only for PHP < 8

### DIFF
--- a/src/WooCommerce/HttpClient/BasicAuth.php
+++ b/src/WooCommerce/HttpClient/BasicAuth.php
@@ -19,7 +19,7 @@ class BasicAuth
     /**
      * cURL handle.
      *
-     * @var resource
+     * @var resource|\CurlHandle
      */
     protected $ch;
 
@@ -54,11 +54,11 @@ class BasicAuth
     /**
      * Initialize Basic Authentication class.
      *
-     * @param resource $ch             cURL handle.
-     * @param string   $consumerKey    Consumer key.
-     * @param string   $consumerSecret Consumer Secret.
-     * @param bool     $doQueryString  Do or not query string auth.
-     * @param array    $parameters     Request parameters.
+     * @param resource|\CurlHandle $ch             cURL handle.
+     * @param string               $consumerKey    Consumer key.
+     * @param string               $consumerSecret Consumer Secret.
+     * @param bool                 $doQueryString  Do or not query string auth.
+     * @param array                $parameters     Request parameters.
      */
     public function __construct($ch, $consumerKey, $consumerSecret, $doQueryString, $parameters = [])
     {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -27,7 +27,7 @@ class HttpClient
     /**
      * cURL handle.
      *
-     * @var resource
+     * @var resource|\CurlHandle
      */
     protected $ch;
 
@@ -450,7 +450,10 @@ class HttpClient
             throw new HttpClientException('cURL Error: ' . \curl_error($this->ch), 0, $request, $response);
         }
 
-        \curl_close($this->ch);
+        // we have to call curl_close only for PHP < 8
+        if (\is_resource($this->ch)) {
+            \curl_close($this->ch);
+        }
 
         return $this->processResponse();
     }


### PR DESCRIPTION
In PHP < 8, `curl_init()` returns a `resource` that must be explicitly closed using `curl_close()` to avoid memory leaks.

Starting with PHP 8, `curl_init()` returns a `CurlHandle` object which is automatically cleaned up by the garbage collector. Calling `curl_close()` on it has no effect and triggers a deprecation warning in PHP 8.5+.

This change ensures `curl_close()` is only called for `resource` handles.