### PR TITLE
Fix CI workflow and add PHP 8.2-8.5 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer
@@ -26,6 +26,6 @@ jobs:
           php --version
           composer --version
       - name: Install composer packages
-        run: ./.github/bin/install-dependencies
+        run: composer install --no-interaction --prefer-dist
       - name: Run tests
-        run: ./.github/bin/run-phpunit
+        run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-text

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer


### PR DESCRIPTION
## Summary
- Fix `ci.yml` to use direct composer/phpunit commands instead of non-existent `.github/bin/` scripts that were causing CI failures
- Add PHP 8.2, 8.3, 8.4, and 8.5 to the test matrix in both `ci.yml` and `pr-unit-tests.yml`
- Update `actions/checkout` from v2 to v4
- Update `shivammathur/setup-php` to use the `@v2` tag instead of a pinned commit

## Problem
The trunk CI has been failing because it references scripts that don't exist:
- `.github/bin/install-dependencies`
- `.github/bin/run-phpunit`

See: https://github.com/woocommerce/wc-api-php/actions/runs/21522685102/job/62017957837

## Test plan
- [x] Verify CI passes on this PR for all PHP versions
- [ ] Merge and verify trunk CI is green