### PR TITLE
Fix incorrect @return phpdoc types in Client class

### DIFF
--- a/src/WooCommerce/Client.php
+++ b/src/WooCommerce/Client.php
@@ -49,7 +49,7 @@ class Client
      * @param string $endpoint API endpoint.
      * @param array  $data     Request data.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function post($endpoint, $data)
     {
@@ -62,7 +62,7 @@ class Client
      * @param string $endpoint API endpoint.
      * @param array  $data     Request data.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function put($endpoint, $data)
     {
@@ -88,7 +88,7 @@ class Client
      * @param string $endpoint   API endpoint.
      * @param array  $parameters Request parameters.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function delete($endpoint, $parameters = [])
     {
@@ -100,7 +100,7 @@ class Client
      *
      * @param string $endpoint API endpoint.
      *
-     * @return \stdClass
+     * @return \stdClass|array
      */
     public function options($endpoint)
     {


### PR DESCRIPTION
## Problem

The `Client` methods (`post`, `put`, `delete`, `options`) document their return type as `\stdClass`, but `json_decode()` (used in `HttpClient::processResponse()`) returns an `array` when the JSON response is a JSON array. This causes phpstan/phpcs type-checking errors for users who rely on the documented return type.

See issue #329 for details.

## Solution

Update the `@return` phpdoc on `post()`, `put()`, `delete()`, and `options()` from `\stdClass` to `\stdClass|array`, which is consistent with the existing phpdoc on `HttpClient::request()` and `HttpClient::processResponse()`.

## Changes

- `src/WooCommerce/Client.php`: Updated `@return` tags on `post()`, `put()`, `delete()`, and `options()` methods.

Fixes #329